### PR TITLE
Make sure all setCapabilityValue promises has finished before triggers + "todays lowes/highest prices fix"

### DIFF
--- a/drivers/home/device.ts
+++ b/drivers/home/device.ts
@@ -487,7 +487,7 @@ class HomeDevice extends Device {
           .catch(console.error);
 
         this.#priceAmongHighestTrigger
-          .trigger(this, undefined, { lowest: true })
+          .trigger(this, undefined, { lowest: false })
           .catch(console.error);
 
         if (this.#priceMinMaxComparer({}, { lowest: true })) {
@@ -730,7 +730,7 @@ class HomeDevice extends Device {
     if (options.ranked_hours !== undefined) {
       const sortedHours = _.sortBy(pricesNextHours, ['total']);
       const currentHourRank = _.findIndex(
-        pricesNextHours,
+          sortedHours,
         (p) => p.startsAt === this.#lastPrice?.startsAt,
       );
       if (currentHourRank < 0) {


### PR DESCRIPTION
Users, including me, seems to expect global tags are set when the triggers are fired.

Use the code if you want to. I've tested a bit with this code and it seems to work more consistant. Before the change the global tags did not update as long as I tested it (over a few days) in time to be updated when the "price changed" trigger triggered.

