### PR TITLE
feat: add `meter_power.imported` and `meter_power.exported` accumulated capabilities

### DIFF
--- a/app.json
+++ b/app.json
@@ -1208,10 +1208,14 @@
         "accumulatedCost",
         "measure_current.L1",
         "measure_current.L2",
-        "measure_current.L3"
+        "measure_current.L3",
+        "meter_power.imported",
+        "meter_power.exported"
       ],
       "energy": {
-        "cumulative": true
+        "cumulative": true,
+        "cumulativeImportedCapability": "meter_power.imported",
+        "cumulativeExportedCapability": "meter_power.exported"
       },
       "capabilitiesOptions": {
         "accumulatedCost": {
@@ -1451,10 +1455,14 @@
         "accumulatedCost",
         "measure_current.L1",
         "measure_current.L2",
-        "measure_current.L3"
+        "measure_current.L3",
+        "meter_power.imported",
+        "meter_power.exported"
       ],
       "energy": {
-        "cumulative": true
+        "cumulative": true,
+        "cumulativeImportedCapability": "meter_power.imported",
+        "cumulativeExportedCapability": "meter_power.exported"
       },
       "capabilitiesOptions": {
         "accumulatedCost": {

--- a/drivers/pulse/device.ts
+++ b/drivers/pulse/device.ts
@@ -348,6 +348,32 @@ class PulseDevice extends Device {
             .catch(console.error);
         });
     }
+
+    const lastMeterConsumption =
+      result.data?.liveMeasurement?.lastMeterConsumption;
+    if (typeof lastMeterConsumption === 'number') {
+      if (this.hasCapability('meter_power.imported') !== true)
+        await this.addCapability('meter_power.imported').catch(console.error);
+
+      const fixedLastMeterConsumption = Number(lastMeterConsumption.toFixed(2));
+      this.setCapabilityValue(
+        'meter_power.imported',
+        fixedLastMeterConsumption,
+      ).catch(console.error);
+    }
+
+    const lastMeterProduction =
+      result.data?.liveMeasurement?.lastMeterProduction;
+    if (typeof lastMeterProduction === 'number') {
+      if (this.hasCapability('meter_power.exported') !== true)
+        await this.addCapability('meter_power.exported').catch(console.error);
+
+      const fixedLastMeterProduction = Number(lastMeterProduction.toFixed(2));
+      this.setCapabilityValue(
+        'meter_power.exported',
+        fixedLastMeterProduction,
+      ).catch(console.error);
+    }
   }
 
   onDeleted() {

--- a/drivers/pulse/driver.compose.json
+++ b/drivers/pulse/driver.compose.json
@@ -10,10 +10,14 @@
     "accumulatedCost",
     "measure_current.L1",
     "measure_current.L2",
-    "measure_current.L3"
+    "measure_current.L3",
+    "meter_power.imported",
+    "meter_power.exported"
   ],
   "energy": {
-    "cumulative": true
+    "cumulative": true,
+    "cumulativeImportedCapability": "meter_power.imported",
+    "cumulativeExportedCapability": "meter_power.exported"
   },
   "capabilitiesOptions": {
     "accumulatedCost": {

--- a/drivers/watty/device.ts
+++ b/drivers/watty/device.ts
@@ -350,6 +350,32 @@ class WattyDevice extends Device {
           });
       }
     }
+
+    const lastMeterConsumption =
+      result.data?.liveMeasurement?.lastMeterConsumption;
+    if (typeof lastMeterConsumption === 'number') {
+      if (this.hasCapability('meter_power.imported') !== true)
+        await this.addCapability('meter_power.imported').catch(console.error);
+
+      const fixedLastMeterConsumption = Number(lastMeterConsumption.toFixed(2));
+      this.setCapabilityValue(
+        'meter_power.imported',
+        fixedLastMeterConsumption,
+      ).catch(console.error);
+    }
+
+    const lastMeterProduction =
+      result.data?.liveMeasurement?.lastMeterProduction;
+    if (typeof lastMeterProduction === 'number') {
+      if (this.hasCapability('meter_power.exported') !== true)
+        await this.addCapability('meter_power.exported').catch(console.error);
+
+      const fixedLastMeterProduction = Number(lastMeterProduction.toFixed(2));
+      this.setCapabilityValue(
+        'meter_power.exported',
+        fixedLastMeterProduction,
+      ).catch(console.error);
+    }
   }
 
   onDeleted() {

--- a/drivers/watty/driver.compose.json
+++ b/drivers/watty/driver.compose.json
@@ -10,10 +10,14 @@
     "accumulatedCost",
     "measure_current.L1",
     "measure_current.L2",
-    "measure_current.L3"
+    "measure_current.L3",
+    "meter_power.imported",
+    "meter_power.exported"
   ],
   "energy": {
-    "cumulative": true
+    "cumulative": true,
+    "cumulativeImportedCapability": "meter_power.imported",
+    "cumulativeExportedCapability": "meter_power.exported"
   },
   "capabilitiesOptions": {
     "accumulatedCost": {

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -31,6 +31,8 @@ export interface LiveMeasurement {
       power: number;
       accumulatedConsumption: number;
       accumulatedCost: number | null;
+      lastMeterConsumption: number | null;
+      lastMeterProduction: number | null;
       currency: string | null;
       minPower: number;
       averagePower: number;

--- a/lib/queries.ts
+++ b/lib/queries.ts
@@ -106,6 +106,8 @@ export const queries = {
         power
         accumulatedConsumption
         accumulatedCost
+        lastMeterConsumption
+        lastMeterProduction
         currency
         minPower
         averagePower


### PR DESCRIPTION
By adding these capabilities Homey gets more insight into the users' accumulated energy consumption and production (see [developer documentation](https://apps.developer.homey.app/the-basics/devices/energy#measuring-devices)).

Note: this is untested code, but based on the documentation and API explorer this should work.