### PR TITLE
Select number of phases setting

### DIFF
--- a/app.json
+++ b/app.json
@@ -1430,6 +1430,19 @@
               ]
             }
           ]
+        },
+        {
+          "id": "phase_mode",
+          "type": "checkbox",
+          "label": {
+            "en": "Show 3 phases",
+            "no": "Vis 3 faser"
+          },
+          "hint": {
+            "en": "Enables 3 phase mode\nDefault: true\n\nWill show current on separate phases 1, 2 and 3/nTurn off to show only one phase",
+            "no": "Aktiverer 3-fase modus\nDefault: true\n\nViser strøm på fase 1, 2 og 3 separat/nSlå av for å vise kun én fase."
+          },
+          "value": true
         }
       ],
       "id": "pulse"

--- a/app.json
+++ b/app.json
@@ -1686,6 +1686,19 @@
               ]
             }
           ]
+        },
+        {
+          "id": "phase_mode",
+          "type": "checkbox",
+          "label": {
+            "en": "Show 3 phases",
+            "no": "Vis 3 faser"
+          },
+          "hint": {
+            "en": "Enables 3 phase mode\nDefault: true\n\nWill show current on separate phases 1, 2 and 3/nTurn off to show only one phase",
+            "no": "Aktiverer 3-fase modus\nDefault: true\n\nViser strøm på fase 1, 2 og 3 separat/nSlå av for å vise kun én fase."
+          },
+          "value": true
         }
       ],
       "id": "watty"

--- a/app.json
+++ b/app.json
@@ -1432,17 +1432,45 @@
           ]
         },
         {
-          "id": "phase_mode",
-          "type": "checkbox",
+          "type": "group",
           "label": {
-            "en": "Show 3 phases",
-            "no": "Vis 3 faser"
+            "en": "Show/hide phases"
           },
-          "hint": {
-            "en": "Enables 3 phase mode\nDefault: true\n\nWill show current on separate phases 1, 2 and 3/nTurn off to show only one phase",
-            "no": "Aktiverer 3-fase modus\nDefault: true\n\nViser strøm på fase 1, 2 og 3 separat/nSlå av for å vise kun én fase."
-          },
-          "value": true
+          "children": [
+            {
+              "id": "show_phase_current_L1",
+              "type": "checkbox",
+              "label": {
+                "en": "Show current phase 1"
+              },
+              "value": true,
+              "hint": {
+                "en": "Show phase 1 current\nDisable to hide value from dashboard\n\nRemoves relevant flow cards and tokens\nDefault: true"
+              }
+            },
+            {
+              "id": "show_phase_current_L2",
+              "type": "checkbox",
+              "label": {
+                "en": "Show current phase 2"
+              },
+              "value": true,
+              "hint": {
+                "en": "Show phase 2 current\nDisable to hide value from dashboard\n\nRemoves relevant flow cards and tokens\nDefault: true"
+              }
+            },
+            {
+              "id": "show_phase_current_L3",
+              "type": "checkbox",
+              "label": {
+                "en": "Show current phase 3"
+              },
+              "value": true,
+              "hint": {
+                "en": "Show phase 3 current\nDisable to hide value from dashboard\n\nRemoves relevant flow cards and tokens\nDefault: true"
+              }
+            }
+          ]
         }
       ],
       "id": "pulse"
@@ -1688,17 +1716,45 @@
           ]
         },
         {
-          "id": "phase_mode",
-          "type": "checkbox",
+          "type": "group",
           "label": {
-            "en": "Show 3 phases",
-            "no": "Vis 3 faser"
+            "en": "Show/hide phases"
           },
-          "hint": {
-            "en": "Enables 3 phase mode\nDefault: true\n\nWill show current on separate phases 1, 2 and 3/nTurn off to show only one phase",
-            "no": "Aktiverer 3-fase modus\nDefault: true\n\nViser strøm på fase 1, 2 og 3 separat/nSlå av for å vise kun én fase."
-          },
-          "value": true
+          "children": [
+            {
+              "id": "show_phase_current_L1",
+              "type": "checkbox",
+              "label": {
+                "en": "Show current phase 1"
+              },
+              "value": true,
+              "hint": {
+                "en": "Show phase 1 current\nDisable to hide value from dashboard\n\nRemoves relevant flow cards and tokens\nDefault: true"
+              }
+            },
+            {
+              "id": "show_phase_current_L2",
+              "type": "checkbox",
+              "label": {
+                "en": "Show current phase 2"
+              },
+              "value": true,
+              "hint": {
+                "en": "Show phase 2 current\nDisable to hide value from dashboard\n\nRemoves relevant flow cards and tokens\nDefault: true"
+              }
+            },
+            {
+              "id": "show_phase_current_L3",
+              "type": "checkbox",
+              "label": {
+                "en": "Show current phase 3"
+              },
+              "value": true,
+              "hint": {
+                "en": "Show phase 3 current\nDisable to hide value from dashboard\n\nRemoves relevant flow cards and tokens\nDefault: true"
+              }
+            }
+          ]
         }
       ],
       "id": "watty"

--- a/drivers/pulse/device.ts
+++ b/drivers/pulse/device.ts
@@ -15,6 +15,7 @@ class PulseDevice extends Device {
   #currency?: string;
   #cachedNordPoolPrice: { hour: number; price: number } | null = null;
   #area?: string;
+  #phaseMode!: boolean;
   #prevPowerProduction?: number;
   #prevUpdate?: moment.Moment;
   #prevPower?: number;
@@ -40,6 +41,7 @@ class PulseDevice extends Device {
     this.#api = new TibberApi(this.log, this.homey.settings, id, token);
     this.#deviceId = id;
     this.#throttle = this.getSetting('pulse_throttle') || 30;
+    this.#phaseMode = this.getSetting('phase_mode') || true;
 
     this.#powerChangedTrigger =
       this.homey.flow.getDeviceTriggerCard('power_changed');
@@ -106,6 +108,19 @@ class PulseDevice extends Device {
       this.log('Updated area value: ', newSettings.pulse_area);
       this.#area = newSettings.pulse_area;
       this.#cachedNordPoolPrice = null;
+    }
+    if (changedKeys.includes('phase_mode')) {
+      this.log('Updated 3-phase mode value: ', Boolean(newSettings.phase_mode));
+      this.#phaseMode = Boolean(newSettings.phase_mode);
+      if (this.#phaseMode) {
+        this.log('3-phase mode enabled');
+        await this.addCapability('measure_current.L2');
+        await this.addCapability('measure_current.L3');
+      } else {
+        this.log('3-phase mode disabled');
+        await this.removeCapability('measure_current.L2');
+        await this.removeCapability('measure_current.L3');
+      }
     }
   }
 

--- a/drivers/pulse/device.ts
+++ b/drivers/pulse/device.ts
@@ -15,7 +15,6 @@ class PulseDevice extends Device {
   #currency?: string;
   #cachedNordPoolPrice: { hour: number; price: number } | null = null;
   #area?: string;
-  #phaseMode!: boolean;
   #prevPowerProduction?: number;
   #prevUpdate?: moment.Moment;
   #prevPower?: number;
@@ -41,7 +40,6 @@ class PulseDevice extends Device {
     this.#api = new TibberApi(this.log, this.homey.settings, id, token);
     this.#deviceId = id;
     this.#throttle = this.getSetting('pulse_throttle') || 30;
-    this.#phaseMode = this.getSetting('phase_mode') || true;
 
     this.#powerChangedTrigger =
       this.homey.flow.getDeviceTriggerCard('power_changed');
@@ -109,17 +107,26 @@ class PulseDevice extends Device {
       this.#area = newSettings.pulse_area;
       this.#cachedNordPoolPrice = null;
     }
-    if (changedKeys.includes('phase_mode')) {
-      this.log('Updated 3-phase mode value: ', Boolean(newSettings.phase_mode));
-      this.#phaseMode = Boolean(newSettings.phase_mode);
-      if (this.#phaseMode) {
-        this.log('3-phase mode enabled');
-        await this.addCapability('measure_current.L2');
-        await this.addCapability('measure_current.L3');
-      } else {
-        this.log('3-phase mode disabled');
-        await this.removeCapability('measure_current.L2');
-        await this.removeCapability('measure_current.L3');
+    // Handle phase current visibility settings
+    const phases = ['L1', 'L2', 'L3'];
+    for (const phase of phases) {
+      const settingKey = `show_phase_current_${phase}`;
+      if (changedKeys.includes(settingKey)) {
+        this.log(`Updated show phase current ${phase} value: `, Boolean(newSettings[settingKey]));
+        const showPhase = Boolean(newSettings[settingKey]);
+        
+        if (showPhase) {
+          this.log(`Adding measure_current.${phase} capability to dashboard`);
+          await this.setCapabilityOptions(`measure_current.${phase}`, {
+            uiComponent: 'sensor'
+          });
+        } else {
+          this.log(`Removing measure_current.${phase} capability from dashboard`);
+          await this.setCapabilityOptions(`measure_current.${phase}`, {
+            uiComponent: 'none'
+          });
+        }
+        
       }
     }
   }

--- a/drivers/pulse/driver.compose.json
+++ b/drivers/pulse/driver.compose.json
@@ -232,6 +232,19 @@
           ]
         }
       ]
+    },
+    {
+      "id": "phase_mode",
+      "type": "checkbox",
+      "label": {
+        "en": "Show 3 phases",
+        "no": "Vis 3 faser"
+      },
+      "hint": {
+        "en": "Enables 3 phase mode\nDefault: true\n\nWill show current on separate phases 1, 2 and 3/nTurn off to show only one phase",
+        "no": "Aktiverer 3-fase modus\nDefault: true\n\nViser strøm på fase 1, 2 og 3 separat/nSlå av for å vise kun én fase."
+      },
+      "value": true
     }
   ]
 }

--- a/drivers/pulse/driver.compose.json
+++ b/drivers/pulse/driver.compose.json
@@ -234,17 +234,45 @@
       ]
     },
     {
-      "id": "phase_mode",
-      "type": "checkbox",
-      "label": {
-        "en": "Show 3 phases",
-        "no": "Vis 3 faser"
-      },
-      "hint": {
-        "en": "Enables 3 phase mode\nDefault: true\n\nWill show current on separate phases 1, 2 and 3/nTurn off to show only one phase",
-        "no": "Aktiverer 3-fase modus\nDefault: true\n\nViser strøm på fase 1, 2 og 3 separat/nSlå av for å vise kun én fase."
-      },
-      "value": true
+      "type": "group",
+        "label": {
+          "en": "Show/hide phases"
+        },
+        "children": [
+          {
+            "id": "show_phase_current_L1",
+            "type": "checkbox",
+            "label": {
+              "en": "Show current phase 1"
+            },
+            "value": true,
+            "hint": {
+              "en": "Show phase 1 current\nDisable to hide value from dashboard\n\nRemoves relevant flow cards and tokens\nDefault: true"
+            }
+          },
+          {
+            "id": "show_phase_current_L2",
+            "type": "checkbox",
+            "label": {
+              "en": "Show current phase 2"
+            },
+            "value": true,
+            "hint": {
+              "en": "Show phase 2 current\nDisable to hide value from dashboard\n\nRemoves relevant flow cards and tokens\nDefault: true"
+            }
+          },
+          {
+            "id": "show_phase_current_L3",
+            "type": "checkbox",
+            "label": {
+              "en": "Show current phase 3"
+            },
+            "value": true,
+            "hint": {
+              "en": "Show phase 3 current\nDisable to hide value from dashboard\n\nRemoves relevant flow cards and tokens\nDefault: true"
+            }
+          }
+        ]
     }
   ]
 }

--- a/drivers/watty/device.ts
+++ b/drivers/watty/device.ts
@@ -15,7 +15,6 @@ class WattyDevice extends Device {
   #currency?: string;
   #cachedNordPoolPrice: { hour: number; price: number } | null = null;
   #area?: string;
-  #phaseMode!: boolean;
   #prevPowerProduction?: number;
   #prevUpdate?: moment.Moment;
   #prevPower?: number;
@@ -41,7 +40,6 @@ class WattyDevice extends Device {
     this.#api = new TibberApi(this.log, this.homey.settings, id, token);
     this.#deviceId = id;
     this.#throttle = this.getSetting('pulse_throttle') || 30;
-    this.#phaseMode = this.getSetting('phase_mode') || true;
 
     this.#powerChangedTrigger = this.homey.flow.getDeviceTriggerCard(
       'watty_power_changed',
@@ -108,17 +106,26 @@ class WattyDevice extends Device {
       this.#area = newSettings.pulse_area;
       this.#cachedNordPoolPrice = null;
     }
-    if (changedKeys.includes('phase_mode')) {
-      this.log('Updated 3-phase mode value: ', Boolean(newSettings.phase_mode));
-      this.#phaseMode = Boolean(newSettings.phase_mode);
-      if (this.#phaseMode) {
-        this.log('3-phase mode enabled');
-        await this.addCapability('measure_current.L2');
-        await this.addCapability('measure_current.L3');
-      } else {
-        this.log('3-phase mode disabled');
-        await this.removeCapability('measure_current.L2');
-        await this.removeCapability('measure_current.L3');
+    // Handle phase current visibility settings
+    const phases = ['L1', 'L2', 'L3'];
+    for (const phase of phases) {
+      const settingKey = `show_phase_current_${phase}`;
+      if (changedKeys.includes(settingKey)) {
+        this.log(`Updated show phase current ${phase} value: `, Boolean(newSettings[settingKey]));
+        const showPhase = Boolean(newSettings[settingKey]);
+        
+        if (showPhase) {
+          this.log(`Adding measure_current.${phase} capability to dashboard`);
+          await this.setCapabilityOptions(`measure_current.${phase}`, {
+            uiComponent: 'sensor'
+          });
+        } else {
+          this.log(`Removing measure_current.${phase} capability from dashboard`);
+          await this.setCapabilityOptions(`measure_current.${phase}`, {
+            uiComponent: 'none'
+          });
+        }
+        
       }
     }
   }

--- a/drivers/watty/driver.compose.json
+++ b/drivers/watty/driver.compose.json
@@ -231,7 +231,20 @@
             }
           ]
         }
-      ]
+      ]    
+    },
+    {
+      "id": "phase_mode",
+      "type": "checkbox",
+      "label": {
+        "en": "Show 3 phases",
+        "no": "Vis 3 faser"
+      },
+      "hint": {
+        "en": "Enables 3 phase mode\nDefault: true\n\nWill show current on separate phases 1, 2 and 3/nTurn off to show only one phase",
+        "no": "Aktiverer 3-fase modus\nDefault: true\n\nViser strøm på fase 1, 2 og 3 separat/nSlå av for å vise kun én fase."
+      },
+      "value": true
     }
   ]
 }

--- a/drivers/watty/driver.compose.json
+++ b/drivers/watty/driver.compose.json
@@ -234,17 +234,45 @@
       ]    
     },
     {
-      "id": "phase_mode",
-      "type": "checkbox",
-      "label": {
-        "en": "Show 3 phases",
-        "no": "Vis 3 faser"
-      },
-      "hint": {
-        "en": "Enables 3 phase mode\nDefault: true\n\nWill show current on separate phases 1, 2 and 3/nTurn off to show only one phase",
-        "no": "Aktiverer 3-fase modus\nDefault: true\n\nViser strøm på fase 1, 2 og 3 separat/nSlå av for å vise kun én fase."
-      },
-      "value": true
+      "type": "group",
+        "label": {
+          "en": "Show/hide phases"
+        },
+        "children": [
+          {
+            "id": "show_phase_current_L1",
+            "type": "checkbox",
+            "label": {
+              "en": "Show current phase 1"
+            },
+            "value": true,
+            "hint": {
+              "en": "Show phase 1 current\nDisable to hide value from dashboard\n\nRemoves relevant flow cards and tokens\nDefault: true"
+            }
+          },
+          {
+            "id": "show_phase_current_L2",
+            "type": "checkbox",
+            "label": {
+              "en": "Show current phase 2"
+            },
+            "value": true,
+            "hint": {
+              "en": "Show phase 2 current\nDisable to hide value from dashboard\n\nRemoves relevant flow cards and tokens\nDefault: true"
+            }
+          },
+          {
+            "id": "show_phase_current_L3",
+            "type": "checkbox",
+            "label": {
+              "en": "Show current phase 3"
+            },
+            "value": true,
+            "hint": {
+              "en": "Show phase 3 current\nDisable to hide value from dashboard\n\nRemoves relevant flow cards and tokens\nDefault: true"
+            }
+          }
+        ]
     }
   ]
 }


### PR DESCRIPTION
# Why
On a 1-phase power-grid we do not need the two empty phases measuring no current, so I wanted a setting to hide them from capabilities view.

# What
I added a checkbox setting to the Pulse and Watty drivers
Default value is true (most people have 3-phases)
Upon change it removes/adds the capabilities **measure_current.L2** and **measure_current.L3** on the device

# Test
Tested on Pulse. :heavy_check_mark:
Watty not tested, but should work similarly.