### PR TITLE
Set device unavailable only when realTimeConsumptionEnabled is false

### DIFF
--- a/drivers/pulse/device.ts
+++ b/drivers/pulse/device.ts
@@ -130,7 +130,7 @@ class PulseDevice extends Device {
       const { viewer } = await this.#api.getHomeFeatures(this);
       websocketSubscriptionUrl = viewer.websocketSubscriptionUrl;
 
-      if (!viewer?.home?.features?.realTimeConsumptionEnabled) {
+      if (viewer?.home?.features?.realTimeConsumptionEnabled === false) {
         this.log(
           `Home with id ${
             this.#deviceId

--- a/drivers/watty/device.ts
+++ b/drivers/watty/device.ts
@@ -129,7 +129,7 @@ class WattyDevice extends Device {
       const { viewer } = await this.#api.getHomeFeatures(this);
       websocketSubscriptionUrl = viewer.websocketSubscriptionUrl;
 
-      if (!viewer?.home?.features?.realTimeConsumptionEnabled) {
+      if (viewer?.home?.features?.realTimeConsumptionEnabled === false) {
         this.log(
           `Home with id ${
             this.#deviceId


### PR DESCRIPTION
Based on discussions in https://github.com/tibber/com.tibber.athom/issues/84 I suspect we might be setting pulse / watty devices unavailable too eagerly when realTimeConsumptionEnabled is undefined, not false. We should collect logs to confirm this though.