### PR TITLE
[pre-approved-scripted] migrate CODEOWNERS to fa-integration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @tibber/squad-smart-home
+* @tibber/fa-integration


### PR DESCRIPTION
## Summary

RFC-093 ownership migration: replaces the stale squad-* CODEOWNERS line in this repo with the FA team that succeeded it (`@tibber/fa-integration`).

No code changes. CODEOWNERS-only edit.

Relates to tibber/tibber-customer#497