### PR TITLE
Version 1.10.4 (force re-publish)

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -205,5 +205,8 @@
   },
   "1.10.3": {
     "en": "Fixes crash on Homey Cloud that affected live data from Pulse and Watty. Pulse and Watty stay available more reliably when the Tibber API returns incomplete data. Security updates."
+  },
+  "1.10.4": {
+    "en": "Maintenance update to ensure all Homey Cloud customers receive the recent fixes."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "com.tibber",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "compatibility": ">=8.1.0",
   "platforms": [
     "local",

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "com.tibber",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "compatibility": ">=8.1.0",
   "platforms": [
     "local",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.tibber",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.tibber",
-      "version": "1.10.3",
+      "version": "1.10.4",
       "license": "ISC",
       "dependencies": {
         "@apollo/client": "^3.14.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.tibber",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "description": "Integration with Tibber",
   "main": "app.ts",
   "scripts": {


### PR DESCRIPTION
Forces version-string advancement so Homey Cloud customers parked on the empty-env build #100 of 1.10.3 migrate to a build with environment variables properly set.

Same code as 1.10.3; version bump only. See #130 (1.10.3) for the substantive crash fix.

## Test plan

- [x] `npm run lint && npm run build && npm test` pass
- [ ] Publish to Test channel via `homey app publish`, watch crash counter, promote to Live