### PR TITLE
Don't permanently kill Pulse device on transient realTimeConsumptionEnabled=false

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -208,5 +208,8 @@
   },
   "1.10.4": {
     "en": "Maintenance update to ensure all Homey Cloud customers receive the recent fixes."
+  },
+  "1.10.5": {
+    "en": "Keep pulse watchdog running for 24 hours after last update to better handle cases where the Tibber API returns incomplete data for an extended period of time."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "com.tibber",
-  "version": "1.10.4",
+  "version": "1.10.5",
   "compatibility": ">=8.1.0",
   "platforms": [
     "local",

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "com.tibber",
-  "version": "1.10.4",
+  "version": "1.10.5",
   "compatibility": ">=8.1.0",
   "platforms": [
     "local",

--- a/drivers/pulse/device.test.ts
+++ b/drivers/pulse/device.test.ts
@@ -1,0 +1,133 @@
+jest.mock('../../lib/newrelic-transaction', () => ({
+  startTransaction: (_n: string, _g: string, fn: () => unknown) => fn(),
+  startSegment: (_n: string, _r: boolean, fn: () => unknown) => fn(),
+  noticeError: jest.fn(),
+  getUserAgent: () => 'test-agent',
+}));
+
+const mockGetHomeFeatures = jest.fn();
+const mockSubscribeToLive = jest.fn();
+
+jest.mock('../../lib/tibber-api', () => ({
+  TibberApi: jest.fn().mockImplementation(() => ({
+    getHomeFeatures: mockGetHomeFeatures,
+    subscribeToLive: mockSubscribeToLive,
+    getDefaultToken: () => 'token-1',
+  })),
+}));
+
+// Minimal Homey Device stand-in — only the surface PulseDevice touches
+class FakeDevice {
+  homey = {
+    settings: {},
+    flow: {
+      getDeviceTriggerCard: () => ({
+        trigger: jest.fn().mockResolvedValue(undefined),
+      }),
+    },
+    platform: 'local',
+    api: { realtime: jest.fn().mockResolvedValue(undefined) },
+    setTimeout: (fn: () => void, ms: number) => setTimeout(fn, ms),
+  };
+  log = jest.fn();
+  getData = () => ({ id: 'home-1', t: 'token-1' });
+  getName = () => 'Test Pulse';
+  getSetting = (_key: string) => null;
+  setUnavailable = jest.fn().mockResolvedValue(undefined);
+  setAvailable = jest.fn().mockResolvedValue(undefined);
+  setCapabilityValue = jest.fn().mockResolvedValue(undefined);
+  hasCapability = () => false;
+  addCapability = jest.fn().mockResolvedValue(undefined);
+}
+
+// Patch Device before requiring the module
+jest.mock('homey', () => ({ Device: FakeDevice, env: {} }), { virtual: true });
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const PulseDeviceModule = require('./device');
+const PulseDevice: new () => FakeDevice & { onInit(): Promise<void> } =
+  PulseDeviceModule;
+
+const fakeSubscription = () => ({
+  subscribe: jest.fn().mockReturnValue({ unsubscribe: jest.fn() }),
+});
+
+function homeResponse(realTimeConsumptionEnabled: boolean | null) {
+  return {
+    viewer: {
+      websocketSubscriptionUrl: 'wss://fake',
+      home: { features: { realTimeConsumptionEnabled } },
+    },
+  };
+}
+
+describe('PulseDevice realTimeConsumptionEnabled=false handling', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockSubscribeToLive.mockReturnValue(fakeSubscription());
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.useRealTimers();
+  });
+
+  test('marks device unavailable but retries after 1 hour when flag is false', async () => {
+    mockGetHomeFeatures.mockResolvedValue(homeResponse(false));
+
+    const device = new PulseDevice();
+    await device.onInit();
+
+    expect(device.setUnavailable).toHaveBeenCalledWith(
+      'Real time consumption is not enabled for this home.',
+    );
+    expect(mockSubscribeToLive).not.toHaveBeenCalled();
+    const callsAfterInit = mockGetHomeFeatures.mock.calls.length;
+
+    // 1-hour debounce fires → another getHomeFeatures call
+    await jest.advanceTimersByTimeAsync(60 * 60 * 1000 + 100);
+
+    expect(mockGetHomeFeatures.mock.calls.length).toBeGreaterThan(callsAfterInit);
+  });
+
+  test('stops retrying after 24 hours of persistent false', async () => {
+    mockGetHomeFeatures.mockResolvedValue(homeResponse(false));
+
+    const device = new PulseDevice();
+    await device.onInit();
+
+    // Advance past 24h so the diff check triggers the cancel
+    jest.setSystemTime(Date.now() + 25 * 60 * 60 * 1000);
+    await jest.advanceTimersByTimeAsync(60 * 60 * 1000 + 100);
+
+    const callsAt24h = mockGetHomeFeatures.mock.calls.length;
+
+    // No further retries
+    await jest.advanceTimersByTimeAsync(5 * 60 * 60 * 1000);
+    expect(mockGetHomeFeatures.mock.calls.length).toBe(callsAt24h);
+  });
+
+  test('reconnects and restores normal debounce interval when flag recovers', async () => {
+    // First check: false. All subsequent: true.
+    mockGetHomeFeatures
+      .mockResolvedValueOnce(homeResponse(false))
+      .mockResolvedValue(homeResponse(true));
+
+    const device = new PulseDevice();
+    await device.onInit();
+
+    expect(mockSubscribeToLive).not.toHaveBeenCalled();
+
+    // 1-hour retry fires, flag is now true → should subscribe
+    await jest.advanceTimersByTimeAsync(60 * 60 * 1000 + 100);
+    expect(mockSubscribeToLive).toHaveBeenCalledTimes(1);
+
+    const callsAfterRecovery = mockGetHomeFeatures.mock.calls.length;
+
+    // Normal watchdog is ~10 min; advancing 15 min should fire it
+    await jest.advanceTimersByTimeAsync(15 * 60 * 1000);
+    expect(mockGetHomeFeatures.mock.calls.length).toBeGreaterThan(
+      callsAfterRecovery,
+    );
+  });
+});

--- a/drivers/pulse/device.ts
+++ b/drivers/pulse/device.ts
@@ -26,6 +26,7 @@ class PulseDevice extends Device {
   #wsSubscription!: Subscription;
   #resubscribeDebounce!: _.DebouncedFunc<() => void>;
   #resubscribeMaxWaitMilliseconds!: number;
+  #realtimeDisabledSince: moment.Moment | null = null;
   #powerChangedTrigger!: FlowCardTriggerDevice;
   #consumptionChangedTrigger!: FlowCardTriggerDevice;
   #costChangedTrigger!: FlowCardTriggerDevice;
@@ -75,11 +76,7 @@ class PulseDevice extends Device {
     this.#resubscribeMaxWaitMilliseconds =
       (jitterSeconds + delaySeconds) * 1000;
 
-    // Resubscribe if no data for delay + jitter
-    this.#resubscribeDebounce = _.debounce(
-      this.#subscribeToLive.bind(this),
-      this.#resubscribeMaxWaitMilliseconds,
-    );
+    this.#resetResubscribeDebounce(this.#resubscribeMaxWaitMilliseconds);
     await this.#subscribeToLive();
   }
 
@@ -109,6 +106,14 @@ class PulseDevice extends Device {
     }
   }
 
+  #resetResubscribeDebounce(waitMs: number) {
+    this.#resubscribeDebounce?.cancel();
+    this.#resubscribeDebounce = _.debounce(
+      this.#subscribeToLive.bind(this),
+      waitMs,
+    );
+  }
+
   async #subscribeToLive() {
     this.#resubscribeDebounce();
 
@@ -131,16 +136,34 @@ class PulseDevice extends Device {
       websocketSubscriptionUrl = viewer.websocketSubscriptionUrl;
 
       if (viewer?.home?.features?.realTimeConsumptionEnabled === false) {
-        this.log(
-          `Home with id ${
-            this.#deviceId
-          } does not have real time consumption enabled. Set device unavailable`,
+        if (this.#realtimeDisabledSince === null) {
+          this.#realtimeDisabledSince = moment();
+          this.log(
+            `Home with id ${this.#deviceId} does not have real time consumption enabled. Will retry for 24 hours before giving up.`,
+          );
+          this.#resetResubscribeDebounce(60 * 60 * 1000);
+        }
+
+        const disabledHours = moment().diff(
+          this.#realtimeDisabledSince,
+          'hours',
         );
-        this.#resubscribeDebounce.cancel();
         await this.setUnavailable(
-          'Tibber home with specified id not found. Please re-add device.',
+          'Real time consumption is not enabled for this home.',
         );
+
+        if (disabledHours >= 24) {
+          this.log(
+            `Real time consumption has been disabled for ${disabledHours} hours. Stopping retries.`,
+          );
+          this.#resubscribeDebounce.cancel();
+        }
         return;
+      }
+
+      if (this.#realtimeDisabledSince !== null) {
+        this.#realtimeDisabledSince = null;
+        this.#resetResubscribeDebounce(this.#resubscribeMaxWaitMilliseconds);
       }
     } catch (e) {
       this.log('Error fetching home features', e);

--- a/drivers/pulse/device.ts
+++ b/drivers/pulse/device.ts
@@ -157,6 +157,8 @@ class PulseDevice extends Device {
             `Real time consumption has been disabled for ${disabledHours} hours. Stopping retries.`,
           );
           this.#resubscribeDebounce.cancel();
+        } else {
+          this.#resubscribeDebounce();
         }
         return;
       }
@@ -164,6 +166,7 @@ class PulseDevice extends Device {
       if (this.#realtimeDisabledSince !== null) {
         this.#realtimeDisabledSince = null;
         this.#resetResubscribeDebounce(this.#resubscribeMaxWaitMilliseconds);
+        this.#resubscribeDebounce();
       }
     } catch (e) {
       this.log('Error fetching home features', e);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.tibber",
-  "version": "1.10.4",
+  "version": "1.10.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.tibber",
-      "version": "1.10.4",
+      "version": "1.10.5",
       "license": "ISC",
       "dependencies": {
         "@apollo/client": "^3.14.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.tibber",
-  "version": "1.10.4",
+  "version": "1.10.5",
   "description": "Integration with Tibber",
   "main": "app.ts",
   "scripts": {


### PR DESCRIPTION
## Summary

- A single `realTimeConsumptionEnabled: false` response from the Tibber API used to immediately cancel the resubscribe watchdog and mark the device permanently unavailable, requiring the user to manually re-pair
- The device now retries for **24 hours** before giving up, on a **1-hour interval** while the flag is false (vs the normal ~10 min) to avoid hammering the API
- If the flag recovers before 24 hours, the device reconnects and the watchdog interval resets to normal
- Also fixes the misleading unavailable message that said "Tibber home with specified id not found" instead of indicating the real cause

🤖 Generated with [Claude Code](https://claude.ai/claude-code)