### PR TITLE
fix: compare price hours by time after day-ahead refresh

### DIFF
--- a/drivers/home/device.ts
+++ b/drivers/home/device.ts
@@ -306,8 +306,9 @@ export class HomeDevice extends Device {
       this.log(`Begin update`);
 
       await startTransaction('GetPriceInfo', 'API', () =>
-        this.#api.populateCachedPriceInfos((callback, ms, args) =>
-          this.homey.setTimeout(callback, ms, args),
+        this.#api.populateCachedPriceInfos(
+          (callback, ms, args) => this.homey.setTimeout(callback, ms, args),
+          () => this.#handlePrice(moment()),
         ),
       );
 

--- a/lib/comparators.test.ts
+++ b/lib/comparators.test.ts
@@ -1,6 +1,6 @@
 import each from 'jest-each';
 import moment from 'moment-timezone';
-import { priceExtremes } from './comparators';
+import { lowestPricesWithinTimeFrame, priceExtremes } from './comparators';
 import { PriceData, TransformedPriceEntry } from './tibber-api';
 
 const logger = () => {};
@@ -113,6 +113,55 @@ describe('comparators', () => {
         );
         expect(actual).toBe(false);
       });
+
+      test('ranked hours still match when latest.startsAt is a cloned Moment', () => {
+        // Scheduled price re-fetch replaces hourlyPrices with new Moment
+        // instances. latest still points at the previous object for the same hour.
+        const now = moment('2023-02-01T00:17:06+01:00');
+        const data = priceData(now);
+        data.latest = {
+          ...data.latest!,
+          startsAt: data.latest!.startsAt.clone(),
+        };
+
+        const actual = priceExtremes(
+          logger,
+          hourlyPrices,
+          data,
+          now,
+          { ranked_hours: 1 },
+          { lowest: true },
+        );
+        expect(actual).toBe(true);
+      });
+    });
+  });
+
+  describe('lowestPricesWithinTimeFrame', () => {
+    test('still matches after price refresh clones Moment instances', () => {
+      const now = moment.tz('Europe/Oslo');
+      const prices: TransformedPriceEntry[] = [];
+      for (let hour = 0; hour < 24; hour += 1) {
+        prices.push({
+          startsAt: now.clone().startOf('day').hour(hour),
+          total: hour === now.hour() ? 0.01 : hour + 1,
+          energy: hour + 1,
+          tax: 0,
+          level: 'NORMAL',
+        });
+      }
+      const current = prices.find((p) => p.startsAt.isSame(now, 'hour'))!;
+      const data: PriceData = {
+        today: prices,
+        latest: { ...current, startsAt: current.startsAt.clone() },
+      };
+
+      const actual = lowestPricesWithinTimeFrame(logger, prices, data, now, {
+        ranked_hours: 1,
+        start_time: '00:00',
+        end_time: '23:59',
+      });
+      expect(actual).toBe(true);
     });
   });
 });

--- a/lib/comparators.test.ts
+++ b/lib/comparators.test.ts
@@ -139,7 +139,9 @@ describe('comparators', () => {
 
   describe('lowestPricesWithinTimeFrame', () => {
     test('still matches after price refresh clones Moment instances', () => {
-      const now = moment.tz('Europe/Oslo');
+      // Mid-day Oslo so the 00:00–23:59 window always contains `now`
+      // (parseTimeString builds start/end on the current local date).
+      const now = moment.tz('Europe/Oslo').startOf('day').hour(12).minute(17);
       const prices: TransformedPriceEntry[] = [];
       for (let hour = 0; hour < 24; hour += 1) {
         prices.push({

--- a/lib/comparators.ts
+++ b/lib/comparators.ts
@@ -10,6 +10,12 @@ import {
   TimeString,
 } from './helpers';
 
+/** Same clock hour — not Moment identity (`===` breaks after a price re-fetch). */
+const isSamePriceHour = (
+  a: moment.Moment | undefined,
+  b: moment.Moment | undefined,
+): boolean => Boolean(a && b && a.isSame(b, 'hour'));
+
 export interface AveragePriceOptions {
   hours: number;
   percentage: number;
@@ -111,8 +117,8 @@ export const priceExtremes = (
   let conditionMet;
   if (rankedHours !== undefined) {
     const sortedPrices = sort(prices).asc((p) => p.total);
-    const currentHourRank = sortedPrices.findIndex(
-      (p) => p.startsAt === priceData.latest?.startsAt,
+    const currentHourRank = sortedPrices.findIndex((p) =>
+      isSamePriceHour(p.startsAt, priceData.latest?.startsAt),
     );
     if (currentHourRank < 0) {
       logger(`Could not find the current hour rank among today's hours`);
@@ -207,8 +213,8 @@ export const lowestPricesWithinTimeFrame = (
   }
 
   const sortedHours = sort(pricesWithinTimeFrame).asc((p) => p.total);
-  const currentHourRank = sortedHours.findIndex(
-    (p) => p.startsAt === priceData.latest?.startsAt,
+  const currentHourRank = sortedHours.findIndex((p) =>
+    isSamePriceHour(p.startsAt, priceData.latest?.startsAt),
   );
   if (currentHourRank < 0) {
     logger(`Could not find the current hour rank among today's hours`);

--- a/lib/tibber-api.ts
+++ b/lib/tibber-api.ts
@@ -235,6 +235,7 @@ export class TibberApi {
       ms: number,
       ...args: unknown[]
     ) => NodeJS.Timeout,
+    onPricesUpdated?: () => void | Promise<void>,
   ): Promise<void> {
     if (this.hourlyPrices.length === 0) {
       this.#log(`No price infos cached. Fetch prices immediately.`);
@@ -294,6 +295,15 @@ export class TibberApi {
           }
 
           this.hourlyPrices = data;
+          // Re-bind device `latest` / capabilities to entries in the new array.
+          try {
+            await onPricesUpdated?.();
+          } catch (refreshError) {
+            console.error(
+              'Failed to refresh current price after re-fetch',
+              refreshError,
+            );
+          }
         }, delay * 1000);
       });
     }


### PR DESCRIPTION
## Problem

The condition **“Current price is one of the [x] lowest prices between [start] and [end]”** (and the ranked “among lowest/highest X hours today” path) intermittently returns `false` even when the current slot is clearly among the cheapest.

This matches [issue #88](https://github.com/tibber/com.tibber.athom/issues/88): it works after a restart, then breaks later the same day, and works again after the next hourly update or another restart.

## Cause

In `lib/comparators.ts`, the current hour is found with:

```ts
sortedHours.findIndex((p) => p.startsAt === priceData.latest?.startsAt)
```

`===` compares **Moment identity**, not the same clock hour.

After the scheduled day-ahead re-fetch (~13:00 Europe/Oslo), `populateCachedPriceInfos` does `this.hourlyPrices = data` (new array, new Moment instances) but does **not** refresh `latest` on the device. Until the next hourly `#handlePrice`, `findIndex` returns `-1` and the condition always returns `false`.

## Fix

1. Compare hours with `startsAt.isSame(latest.startsAt, 'hour')` in both rank lookups (`lowestPricesWithinTimeFrame` and `priceExtremes`).
2. After a scheduled price re-fetch, invoke a callback so the home device re-runs `#handlePrice` and rebinds `latest` to an entry in the new array.

## Tests

Regression tests clone `latest.startsAt` (same timestamp, different instance) and assert the conditions still return the correct boolean — the previous `===` comparison fails that case.

Related: #88